### PR TITLE
Destroy stream without sending EoS marker after reading a msg

### DIFF
--- a/src/post-handshake-transport.ts
+++ b/src/post-handshake-transport.ts
@@ -38,6 +38,8 @@ export class PostHandshakeTransport {
       this.stream.write(ciphertext)
       written += toWrite.length
     }
+
+    this.sendEos()
   }
 
   // Read prefix & decrypt ciphertext segments
@@ -45,7 +47,7 @@ export class PostHandshakeTransport {
     const lenBytes = await this.stream.read(4)
     let len = lenBytes.readUInt32LE(0)
 
-    // Other side terminated gracefully.
+    // Other side terminated gracefully
     if (len === 0) {
       this.destroy()
       return Buffer.alloc(0)
@@ -63,10 +65,9 @@ export class PostHandshakeTransport {
     return plaintext
   }
 
-  destroyGracefully() {
-    // Send end-of-stream marker (0x00 0x00 0x00 0x00) if not ending on an error.
+  sendEos() {
+    // Send end-of-stream marker
     this.stream.write(Buffer.from([0,0,0,0]))
-    this.destroy()
   }
 
   destroy(err?: Error) {

--- a/src/post-handshake-transport.ts
+++ b/src/post-handshake-transport.ts
@@ -47,7 +47,7 @@ export class PostHandshakeTransport {
 
     // Other side terminated gracefully.
     if (len === 0) {
-      this.destroyGracefully()
+      this.destroy()
       return Buffer.alloc(0)
     }
 


### PR DESCRIPTION
A minor change to only send the end-of-stream marker after writing a message.

When reading a message, after having received an end-of-stream marker, we simply destroy the stream (without sending an end-of-stream marker in response).

The Rust-Node interop test now passes in both configurations (initiator / responder) without error.

Prior to this change, Node would throw an error when acting as responder:

```
dupsh "./cli '11111111111111111111111111111111' 'initiator' 'hi from rustland!'" "node ../../cable-handshake.ts/examples/cli.js '3131313131313131313131313131313131313131313131313131313131313131' 'responder' 'greetings from nodeville!'" 
6e9ada58: responder ready!
6e9ada58: got "hi from rustland!"
Received message: greetings from nodeville!
node:events:491
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
    at afterWriteDispatched (node:internal/stream_base_commons:160:15)
    at writeGeneric (node:internal/stream_base_commons:151:3)
    at Socket._writeGeneric (node:net:923:11)
    at Socket._write (node:net:935:8)
    at writeOrBuffer (node:internal/streams/writable:392:12)
    at _write (node:internal/streams/writable:333:10)
    at Writable.write (node:internal/streams/writable:337:10)
    at Socket.ondata (node:internal/streams/readable:766:22)
    at Socket.emit (node:events:513:28)
    at addChunk (node:internal/streams/readable:324:12)
Emitted 'error' event on Socket instance at:
    at Socket.onerror (node:internal/streams/readable:785:14)
    at Socket.emit (node:events:513:28)
    at emitErrorNT (node:internal/streams/destroy:151:8)
    at emitErrorCloseNT (node:internal/streams/destroy:116:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -32,
  code: 'EPIPE',
  syscall: 'write'
}

Node.js v18.13.0
```